### PR TITLE
Add Redis caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # pokemon-card-value-checker
 App checks the value of Pokemon Cards
+
+## Backend Environment Variables
+
+- `POKEMONTCG_API_KEY` – optional key for the PokéTCG API
+- `PORT` – backend port (default `4000`)
+- `REDIS_URL` – Redis connection string used for caching (e.g. `redis://localhost:6379`)
+
+Card and set responses are cached in Redis for about one hour.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,3 +1,4 @@
 # (optional) sign up at https://pokemontcg.io/ to get a free key
 POKEMONTCG_API_KEY=91d52244-c4ad-448f-855c-6d242aeff0c0
 PORT=4000
+REDIS_URL=redis://localhost:6379

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,7 +10,8 @@
         "axios": "^1.10.0",
         "cors": "^2.8.5",
         "dotenv": "^16.5.0",
-        "express": "^4.18.0"
+        "express": "^4.18.0",
+        "redis": "^4.6.7"
     },
     "devDependencies": {
         "nodemon": "^3.1.10"

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -3,12 +3,20 @@ require('dotenv').config({ path: path.resolve(__dirname, '../.env') });
 const express = require('express');
 const cors = require('cors');
 const axios = require('axios');
+const { createClient } = require('redis');
 const { fetchPriceTrackerCardPrices } = require('./priceTracker');
 const { fetchTCGPlayerHolofoilPrices } = require('./tcgplayer');
-const setsRouter = require('./routes/sets');
+const createSetsRouter = require('./routes/sets');
 
 const app = express();
 const PORT = process.env.PORT || 4000;
+
+// Redis client for caching
+const redisClient = createClient({ url: process.env.REDIS_URL });
+redisClient.on('error', err => console.error('Redis error:', err));
+redisClient.connect().catch(err => console.error('Redis connection error:', err));
+
+const CACHE_TTL = 3600; // seconds
 
 app.use(cors());
 app.use(express.json());
@@ -22,6 +30,16 @@ const pokeApi = axios.create({
 app.get('/api/card-info', async (req, res) => {
     const { cardNumber, setId = 'all' } = req.query;
     if (!cardNumber) return res.status(400).json({ error: 'cardNumber required (e.g. 4/102)' });
+
+    const cacheKey = `card-info:${setId}:${cardNumber}`;
+    try {
+        const cached = await redisClient.get(cacheKey);
+        if (cached) {
+            return res.json(JSON.parse(cached));
+        }
+    } catch (err) {
+        console.error('Redis get error:', err);
+    }
 
     try {
         const [number, printedTotal] = String(cardNumber).split('/').map(s => s.trim());
@@ -41,7 +59,9 @@ app.get('/api/card-info', async (req, res) => {
                 set: c.set.name,
                 image: c.images.small
             }));
-            return res.json({ multiple: true, cards });
+            const data = { multiple: true, cards };
+            await redisClient.setEx(cacheKey, CACHE_TTL, JSON.stringify(data));
+            return res.json(data);
         }
 
         // Single match → fetch eBay pricing
@@ -109,7 +129,7 @@ app.get('/api/card-info', async (req, res) => {
                 }
                 : null;
 
-            return res.json({
+            const data = {
                 multiple: false,
                 id: card.id,
                 name: card.name,
@@ -122,7 +142,9 @@ app.get('/api/card-info', async (req, res) => {
                 cardmarket, // add this
                 priceTrackerTCGPlayer, // add this
                 ebayPSAPrices,
-            });
+            };
+            await redisClient.setEx(cacheKey, CACHE_TTL, JSON.stringify(data));
+            return res.json(data);
         } catch (err) {
             console.error('Error fetching eBay data:', err.message || err);
             marketPrice = {
@@ -131,7 +153,7 @@ app.get('/api/card-info', async (req, res) => {
             };
         }
 
-        return res.json({
+        const data = {
             multiple: false,
             id: card.id,
             name: card.name,
@@ -141,13 +163,16 @@ app.get('/api/card-info', async (req, res) => {
             marketPrice,
             ebay,
             tcgplayerPrice
-        });
+        };
+        await redisClient.setEx(cacheKey, CACHE_TTL, JSON.stringify(data));
+        return res.json(data);
     } catch (err) {
         console.error('Server error:', err.message || err);
         return res.status(500).json({ error: 'Server error' });
     }
 });
 
+const setsRouter = createSetsRouter(redisClient, CACHE_TTL);
 app.use('/api/sets', setsRouter);
 
 app.listen(PORT, () =>

--- a/backend/src/routes/sets.js
+++ b/backend/src/routes/sets.js
@@ -1,7 +1,5 @@
 const express = require('express');
-const router = express.Router();
 const { fetchRecentSets } = require('../tcgplayer');
-
 const axios = require('axios');
 const POKEMONTCG_API_KEY = process.env.POKEMONTCG_API_KEY || '';
 const pokeApi = axios.create({
@@ -9,38 +7,56 @@ const pokeApi = axios.create({
     headers: { 'X-Api-Key': POKEMONTCG_API_KEY }
 });
 
-// GET /api/sets?all=true → return all sets for dropdown
-router.get('/', async (req, res) => {
-    try {
-        if (req.query.all === 'true') {
-            // Fetch all sets for dropdown
-            let allSets = [];
-            let page = 1;
-            let pageSize = 250;
-            let totalCount = 0;
-            do {
-                const resp = await pokeApi.get('/sets', {
-                    params: { page, pageSize, orderBy: 'releaseDate' }
-                });
-                allSets = allSets.concat(resp.data.data);
-                totalCount = resp.data.totalCount;
-                page++;
-            } while (allSets.length < totalCount);
-            return res.json(allSets);
-        }
+/**
+ * Create a router for set endpoints with optional Redis caching.
+ * @param {import('redis').RedisClientType} redisClient
+ * @param {number} ttlSeconds
+ */
+module.exports = function createSetsRouter(redisClient, ttlSeconds = 3600) {
+    const router = express.Router();
 
-        // Default: recent sets for banner
+    // GET /api/sets?all=true → return all sets for dropdown
+    router.get('/', async (req, res) => {
+        const isAll = req.query.all === 'true';
         const limit = parseInt(req.query.limit, 10) || 10;
-        const sets = await fetchRecentSets(limit);
-        res.json(sets);
-    } catch (error) {
-        if (error.response) {
-            console.error('Failed to fetch sets:', error.response.data);
-        } else {
-            console.error('Failed to fetch sets:', error.message || error);
-        }
-        res.status(500).json({ error: 'Failed to fetch sets' });
-    }
-});
+        const cacheKey = isAll ? 'sets:all' : `sets:recent:${limit}`;
 
-module.exports = router;
+        try {
+            const cached = await redisClient.get(cacheKey);
+            if (cached) {
+                return res.json(JSON.parse(cached));
+            }
+
+            if (isAll) {
+                let allSets = [];
+                let page = 1;
+                const pageSize = 250;
+                let totalCount = 0;
+                do {
+                    const resp = await pokeApi.get('/sets', {
+                        params: { page, pageSize, orderBy: 'releaseDate' }
+                    });
+                    allSets = allSets.concat(resp.data.data);
+                    totalCount = resp.data.totalCount;
+                    page++;
+                } while (allSets.length < totalCount);
+
+                await redisClient.setEx(cacheKey, ttlSeconds, JSON.stringify(allSets));
+                return res.json(allSets);
+            }
+
+            const sets = await fetchRecentSets(limit);
+            await redisClient.setEx(cacheKey, ttlSeconds, JSON.stringify(sets));
+            res.json(sets);
+        } catch (error) {
+            if (error.response) {
+                console.error('Failed to fetch sets:', error.response.data);
+            } else {
+                console.error('Failed to fetch sets:', error.message || error);
+            }
+            res.status(500).json({ error: 'Failed to fetch sets' });
+        }
+    });
+
+    return router;
+};


### PR DESCRIPTION
## Summary
- add redis dependency
- connect to Redis using `REDIS_URL`
- cache card lookups and set requests
- expose `REDIS_URL` in `.env.example`
- document env vars and caching TTL

## Testing
- `npm -C backend test` *(fails: missing script)*
- `npm --prefix backend install` *(fails: 403 Forbidden - registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686775239fb88327b6bd9fe86535303d

## Summary by Sourcery

Integrate Redis-based caching into the backend to improve performance of card and set lookups.

New Features:
- Cache responses for card lookups and set retrievals using Redis with a one-hour TTL.

Enhancements:
- Refactor the sets router to accept a Redis client and TTL, wrapping data fetches with cache checks and storage.
- Connect to Redis via `REDIS_URL` in the main server entrypoint, handling client setup and errors.

Build:
- Add `redis` as a backend dependency.

Documentation:
- Expose `REDIS_URL` in `.env.example` and update the README with environment variable and caching TTL details.